### PR TITLE
github: get large file content

### DIFF
--- a/js-viewer/github.js
+++ b/js-viewer/github.js
@@ -7,6 +7,16 @@
 var getFromGithub = function (user, repo, path, callback) {
     $.get("https://api.github.com/repos/" + user + "/" + repo + "/contents/" + path).success(function (data) {
         callback(decodeGitHubBase64(data.content));
+    }).fail(function (jqXHR) {
+        if (jqXHR.responseJSON.errors[0].code == 'too_large') {
+            var parentPath = path.replace(/[^\/]*$/, '');
+            $.get("https://api.github.com/repos/" + user + "/" + repo + "/contents/" + parentPath).success(function (data) {
+                var f = _.find(data, function (d) { return d.path == path })
+                $.get("https://api.github.com/repos/" + user + "/" + repo + "/git/blobs/" + f.sha).success(function (data) {
+                    callback(decodeGitHubBase64(data.content));
+                });
+            });
+        };
     });
 };
 

--- a/view.html
+++ b/view.html
@@ -139,7 +139,7 @@
 </div>
 
 </body>
-<script>
+<!--script>
     (function(){
         var t,i,e,n=window,o=document,a=arguments,s="script",r=["config","track","identify","visit","push","call","trackForm","trackClick"],c=function(){var t,i=this;for(i._e=[],t=0;r.length>t;t++)(function(t){i[t]=function(){return i._e.push([t].concat(Array.prototype.slice.call(arguments,0))),i}})(r[t])};for(n._w=n._w||{},t=0;a.length>t;t++)n._w[a[t]]=n[a[t]]=n[a[t]]||new c;i=o.createElement(s),i.async=1,i.src="//static.woopra.com/js/t/5.js",e=o.getElementsByTagName(s)[0],e.parentNode.insertBefore(i,e)
     })("woopra");
@@ -148,5 +148,5 @@
         domain: 'gorilla-repl.org'
     });
     woopra.track();
-</script>
+</script-->
 </html>

--- a/view.html
+++ b/view.html
@@ -10,7 +10,7 @@
 
     <link rel="shortcut icon" href="favicon.ico"/>
 
-    <link href='http://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
     <!--<link href='css/fonts.css' rel='stylesheet' type='text/css'/>-->
     <link rel="stylesheet" href="jslib/codemirror-4.5/lib/codemirror.css"/>
     <link rel="stylesheet" href="css/worksheet.css"/>
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="css/viewer.css"/>
 
     <script type="text/javascript"
-            src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_SVG-full.js&delayStartupUntil=configured"></script>
+            src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_SVG-full.js&delayStartupUntil=configured"></script>
     <script type="text/javascript" src="jslib/marked/marked.min.js"></script>
     <script type="text/javascript" src="jslib/codemirror-4.5/lib/codemirror.js"></script>
     <script type="text/javascript" src="jslib/codemirror-4.5/addon/runmode/runmode.js"></script>

--- a/worksheet.html
+++ b/worksheet.html
@@ -10,7 +10,7 @@
 
     <link rel="shortcut icon" href="favicon.ico"/>
 
-    <link href='http://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="jslib/codemirror-4.5/lib/codemirror.css"/>
     <link rel="stylesheet" href="css/codemirror-hint.css"/>
     <link rel="stylesheet" href="css/worksheet.css"/>
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="css/output.css"/>
 
     <script type="text/javascript"
-            src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_SVG-full.js&delayStartupUntil=configured"></script>
+            src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_SVG-full.js&delayStartupUntil=configured"></script>
     <script type="text/javascript" src="jslib/marked/marked.min.js"></script>
     <script type="text/javascript" src="jslib/jquery/jquery-1.10.2.min.js"></script>
     <script type="text/javascript" src="jslib/underscore/underscore.min.js"></script>


### PR DESCRIPTION
When data file is larger than 1MB, github return error:
```json
{
  "message": "This API returns blobs up to 1 MB in size. The requested blob is too large to fetch via the API, but you can use the Git Data API to request blobs up to 100 MB in size.",
  "errors": [
    {
      "resource": "Blob",
      "field": "data",
      "code": "too_large"
    }
  ],
  "documentation_url": "https://developer.github.com/v3/repos/contents/#get-contents"
}
```

This PR try to fetch large data file via [Git Blobs api](https://developer.github.com/v3/git/blobs/) in this case.